### PR TITLE
Script and documentation updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,6 @@ When starting a new project from this template, update the following before rely
 
 - **Project Overview**, **Tech Stack**, and **Directory Structure** — replace with the new project's details
 - **File Headers** — replace the copyright holder name and starting year
-- **GitHub Repository Topics** — replace the repository link in that step with the new repository
 - **Portfolio Page Generation and Maintenance** — replace the project name and repository URL in the prompt template's Context block
 - **npm Scripts** and **GitHub Actions CI** — prune entries for any scripts or workflows the new project does not keep
 
@@ -43,8 +42,8 @@ Sections not listed above are project-independent and carry over unchanged, unle
 - `npm run build` - bundle the sketch source code and dependencies with `webpack` in production mode
 - `npm run build:dev` - bundle the sketch source code and dependencies with `webpack` in development mode
 - `npm run build:check` - run both build scripts in sequence
-- `npm run serve` - bundle the sketch in production mode, start a localhost development server, and open a new browser window for the `index.html` file bundled with the compiled sketch
-- `npm run dev` - bundle the sketch in development mode, start a localhost development server, and open a new browser window for the `index.html` file bundled with the compiled sketch
+- `npm run preview` - bundle the sketch in production mode, start a localhost development server, and open a new browser window
+- `npm run dev` - bundle the sketch in development mode, start a localhost development server, and open a new browser window
 - `npm run test` - placeholder for a future test runner; the template ships none, and the script exits with an error until one is added
 - `npm run validate` - run lint and build checks in sequence
 
@@ -539,7 +538,7 @@ When reviewing a new page, compare with existing template pages for:
 - label style and format in `Skills and Tooling Inventory` (flat bulleted list with bold category labels)
 - tense and sentence style
 - bullet punctuation consistency
-- naming conventions (`webpack` vs `Webpack`, etc.)
+- naming conventions (match each tool's own capitalization, e.g. `webpack`, `npm`, `Vite`, `ESLint`)
 
 Consistency boosts professionalism at portfolio scale.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Provides an example source structure, build tooling, and GitHub automation for b
 This repository maintains a companion `CLAUDE.md` at the repository root alongside this file.
 This file holds the guidance itself; `CLAUDE.md` is a map of where that guidance lives and does not repeat its rules.
 Add or change a convention here, not in `CLAUDE.md`; a new convention placed under an existing section requires no change to `CLAUDE.md`.
-Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, or a  change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
+Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, a change to the generated output directories, or a change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
 
 ## Using This File in a Project Created From This Template
 
@@ -154,6 +154,12 @@ Any addition, removal, or update to shared sections must be applied consistently
 The Jekyll build uses the `jekyll-relative-links` plugin (configured in `docs/_config.yml`), which automatically converts relative `.md` links in `docs/` markdown files to their rendered `.html` paths.
 For example, `./portfolio-skills.md` in `docs/index.md` resolves to `portfolio-skills.html` on the published site.
 Use `.md` relative links within `docs/` source files; the build process will convert them correctly.
+
+### Front Matter Dates
+
+Markdown pages that carry `date` and `modified_date` front matter render both values through `docs/_layouts/post.html` as "Published" and "Updated".
+When a branch changes the content of one of these pages, bump that page's `modified_date` to the commit date and leave the original `date` unchanged.
+A page whose content did not change keeps its existing `modified_date`.
 
 ## Security and Dependency Management
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,16 +25,16 @@ When the call is close, leave `CLAUDE.md` alone and let the ["Instruction File S
 
 ## Using This File in a Project Created From This Template
 
-This file ships with the template and is intended to be adapted, not copied verbatim.
+This file and its companion `CLAUDE.md` ship with the template and are intended to be adapted, not copied verbatim.
 When starting a new project from this template, update the following before relying on the guidance below:
 
 - **Project Overview**, **Tech Stack**, and **Directory Structure** — replace with the new project's details
 - **File Headers** — replace the copyright holder name and starting year
 - **Portfolio Page Generation and Maintenance** — replace the project name and repository URL in the prompt template's Context block
 - **npm Scripts** and **GitHub Actions CI** — prune entries for any scripts or workflows the new project does not keep
-- **Companion `CLAUDE.md`** — it ships with the template too. Rewrite anything it states in its own words (project summary, generated output directories, the review step list), and re-check every link it makes into this file, since sections renamed or pruned above will break its anchors.
+- **Companion `CLAUDE.md`** — rewrite anything the map states in its own words (project summary, generated output directories, the review step list), and re-check every link it makes into this file, since sections renamed or pruned above will break its anchors
 
-Sections not listed above are project-independent and carry over unchanged, unless the new project drops the tool or platform they document.
+Sections of this file not listed above are project-independent and carry over unchanged, unless the new project drops the tool or platform they document.
 
 ## Tech Stack
 
@@ -234,8 +234,8 @@ Review all branch changes for convention compliance and code quality.
 - All source code files should follow the conventions listed in the ["Development Guidelines" section](#development-guidelines) of this file.
 - Copyright year headers are present and accurate (see ["File Headers" section](#file-headers)).
 - `README.md` and `docs/index.md` are in sync for any shared content changes
-- Test coverage is complete and meaningful for all new or changed public API surface
 - `modified_date` is bumped on every page whose content changed on the branch (see the ["Front Matter Dates" section](#front-matter-dates))
+- Test coverage is complete and meaningful for all new or changed public API surface
 
 #### Code Quality
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Provides an example source structure, build tooling, and GitHub automation for b
 This repository maintains a companion `CLAUDE.md` at the repository root alongside this file.
 This file holds the guidance itself; `CLAUDE.md` is a map of where that guidance lives and does not repeat its rules.
 Add or change a convention here, not in `CLAUDE.md`; a new convention placed under an existing section requires no change to `CLAUDE.md`.
-Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, or a change to the project summary, npm scripts, generated output directories, or the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
+Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, or a  change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
 
 ## Using This File in a Project Created From This Template
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -157,7 +157,7 @@ Use `.md` relative links within `docs/` source files; the build process will con
 
 ### Front Matter Dates
 
-Markdown pages that carry `date` and `modified_date` front matter render both values through `docs/_layouts/post.html` as "Published" and "Updated".
+Markdown pages that use `layout: post` with `date` and `modified_date` front matter render both values through `docs/_layouts/post.html` as "Published" and "Updated", respectively.
 When a branch changes the content of one of these pages, bump that page's `modified_date` to the commit date and leave the original `date` unchanged.
 A page whose content did not change keeps its existing `modified_date`.
 
@@ -194,7 +194,7 @@ If anything changed, do the following:
 
 - Confirm `Capability Record` has 5–7 bullets and `Detailed Technical Notes` has one matching subsection per bullet
 - When a branch introduces a new capability or updates an existing capability, re-rank the highlights against the [selection criteria](#selecting-the-57-highlights) rather than appending; if the new capability ranks in the top 5–7, the lowest-ranked existing highlight comes off the page
-- Bump `modified_date` to today; do not change the original `date`
+- Bump `modified_date` per the ["Front Matter Dates" section](#front-matter-dates); do not change the original `date`
 - Evidence links must always point to the `main` branch
 
 Refer to the ["Portfolio Page Generation and Maintenance" section](#portfolio-page-generation-and-maintenance) for the full review checklist.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,20 @@ Provides an example source structure, build tooling, and GitHub automation for b
 ## Companion Instruction Files
 
 This repository maintains a companion `CLAUDE.md` at the repository root alongside this file.
-This file holds the guidance itself; `CLAUDE.md` is a map of where that guidance lives and does not repeat its rules.
-Add or change a convention here, not in `CLAUDE.md`; a new convention placed under an existing section requires no change to `CLAUDE.md`.
-Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, a change to the generated output directories, or a change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
+This file holds the guidance itself; `CLAUDE.md` is a map of where that guidance lives and does not repeat its rules — the sync rule below is the deliberate exception, since an agent that opens only one of the two files still needs it.
+Add or change a convention here, not in `CLAUDE.md`.
+
+`CLAUDE.md` carries two kinds of content: links into this file, and a small number of facts restated in its own words where a link would cost more than it saves.
+Update `CLAUDE.md` when a change here invalidates either kind:
+
+- **A link stops resolving** — a section `CLAUDE.md` links to is renamed, moved, or removed.
+- **A restated fact stops matching** — a summary, a name, or a list that `CLAUDE.md` spells out rather than links to has changed here.
+
+A new convention added under an existing section invalidates neither, and requires no change to `CLAUDE.md`.
+
+A new *section* is the one case that needs judgment, since a new section is not yet linked from anywhere.
+Add it to the map only if a contributor would need to know the section exists before starting work; leave it off if they would find it by reading this file once they reach the work it governs.
+When the call is close, leave `CLAUDE.md` alone and let the ["Instruction File Sync"](#3-instruction-file-sync) review step revisit it — an incomplete map costs less than a map that drifts into a second copy of this file.
 
 ## Using This File in a Project Created From This Template
 
@@ -21,6 +32,7 @@ When starting a new project from this template, update the following before rely
 - **File Headers** — replace the copyright holder name and starting year
 - **Portfolio Page Generation and Maintenance** — replace the project name and repository URL in the prompt template's Context block
 - **npm Scripts** and **GitHub Actions CI** — prune entries for any scripts or workflows the new project does not keep
+- **Companion `CLAUDE.md`** — it ships with the template too. Rewrite anything it states in its own words (project summary, generated output directories, the review step list), and re-check every link it makes into this file, since sections renamed or pruned above will break its anchors.
 
 Sections not listed above are project-independent and carry over unchanged, unless the new project drops the tool or platform they document.
 
@@ -207,8 +219,10 @@ Editing in place preserves whatever was true when the sections were written; enf
 
 Verify that `CLAUDE.md` and `.github/copilot-instructions.md` are consistent with each other and reflect the current project state:
 
-- `CLAUDE.md` still maps accurately to this file
-- The [Directory Structure section](#directory-structure) accurately reflects the current `src/` module layout
+- Every link in `CLAUDE.md` resolves to a section of this file that still exists under that name
+- Every fact `CLAUDE.md` restates rather than links to still matches this file
+- If the branch added a section to this file, decide whether it belongs on the map, per the ["Companion Instruction Files" section](#companion-instruction-files)
+- The [Directory Structure section](#directory-structure) accurately reflects the current source layout
 - Any new tooling, conventions, or workflows introduced on the branch are documented
 
 ### 4. Branch Code Review
@@ -221,6 +235,7 @@ Review all branch changes for convention compliance and code quality.
 - Copyright year headers are present and accurate (see ["File Headers" section](#file-headers)).
 - `README.md` and `docs/index.md` are in sync for any shared content changes
 - Test coverage is complete and meaningful for all new or changed public API surface
+- `modified_date` is bumped on every page whose content changed on the branch (see the ["Front Matter Dates" section](#front-matter-dates))
 
 #### Code Quality
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository maintains both `CLAUDE.md` and `.github/copilot-instructions.md`
 `CLAUDE.md` is a map of where guidance lives; `.github/copilot-instructions.md` holds the guidance itself.
 Add or change a convention in `.github/copilot-instructions.md`.
 A new convention under an existing section requires no change here.
-Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, or a  change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
+Update `CLAUDE.md` when the map changes: a new or renamed section in `.github/copilot-instructions.md` that this file links to, a change to the project summary, a change to the generated output directories, or a change to the [Pre-Merge and Release Review](./.github/copilot-instructions.md#pre-merge-and-release-review) step list.
 
 ## Project Summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ See the ["npm Scripts" section of `.github/copilot-instructions.md`](./.github/c
   described in the "Portfolio Page Generation and Maintenance" section of
   `.github/copilot-instructions.md`.
 - Markdown indentation rules for all repository `.md` files are in the ["Markdown Formatting" section of `.github/copilot-instructions.md`](./.github/copilot-instructions.md#markdown-formatting).
+- Front matter `date` and `modified_date` rules for pages using `layout: post` are in the ["Front Matter Dates" section of `.github/copilot-instructions.md`](./.github/copilot-instructions.md#front-matter-dates).
 
 ## Pre-Merge and Release Review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,19 @@ This document is a map of what lives there; it does not repeat its rules.
 
 This repository maintains both `CLAUDE.md` and `.github/copilot-instructions.md`.
 `CLAUDE.md` is a map of where guidance lives; `.github/copilot-instructions.md` holds the guidance itself.
-Add or change a convention in `.github/copilot-instructions.md`.
-A new convention under an existing section requires no change here.
-Update `CLAUDE.md` when the map changes: a new or renamed section in `.github/copilot-instructions.md` that this file links to, a change to the project summary, a change to the generated output directories, or a change to the [Pre-Merge and Release Review](./.github/copilot-instructions.md#pre-merge-and-release-review) step list.
+Add or change a convention in `.github/copilot-instructions.md`, not here.
+
+This file carries two kinds of content: links into `.github/copilot-instructions.md`, and a small number of facts restated in its own words where a link would cost more than it saves.
+Update this file when a change there invalidates either kind:
+
+- **A link stops resolving** — a section this file links to is renamed, moved, or removed.
+- **A restated fact stops matching** — a summary, a name, or a list spelled out here rather than linked no longer matches `.github/copilot-instructions.md`.
+
+A new convention added under an existing section invalidates neither, and requires no change here.
+
+A new *section* in `.github/copilot-instructions.md` is the one case that needs judgment, since it is not yet linked from anywhere.
+Add it to the map only if a contributor would need to know the section exists before starting work; leave it off if they would find it by reading `.github/copilot-instructions.md` once they reach the work it governs.
+When the call is close, leave this file alone — an incomplete map costs less than a map that drifts into a second copy.
 
 ## Project Summary
 
@@ -36,7 +46,6 @@ See the ["npm Scripts" section of `.github/copilot-instructions.md`](./.github/c
   described in the "Portfolio Page Generation and Maintenance" section of
   `.github/copilot-instructions.md`.
 - Markdown indentation rules for all repository `.md` files are in the ["Markdown Formatting" section of `.github/copilot-instructions.md`](./.github/copilot-instructions.md#markdown-formatting).
-- Front matter `date` and `modified_date` rules for pages using `layout: post` are in the ["Front Matter Dates" section of `.github/copilot-instructions.md`](./.github/copilot-instructions.md#front-matter-dates).
 
 ## Pre-Merge and Release Review
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository maintains both `CLAUDE.md` and `.github/copilot-instructions.md`
 `CLAUDE.md` is a map of where guidance lives; `.github/copilot-instructions.md` holds the guidance itself.
 Add or change a convention in `.github/copilot-instructions.md`.
 A new convention under an existing section requires no change here.
-Update `CLAUDE.md` when the map changes: a new or renamed section in `.github/copilot-instructions.md` that this file links to, or a change to the project summary, npm commands, generated output directories, or the review step list.
+Update `CLAUDE.md` when the map changes: a new or renamed section that `CLAUDE.md` links to, a change to the project summary, or a  change to the [Pre-Merge and Release Review](#pre-merge-and-release-review) step list.
 
 ## Project Summary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code (and other AI assistants) when working in this reposito
 
 The detailed, authoritative conventions for this project live in [`.github/copilot-instructions.md`](./.github/copilot-instructions.md).
 Read that file before making any change to this repository, including documentation-only changes.
-This document is a map of what lives there; it does not repeat its rules.
+This document is a map of what lives there; it does not repeat its rules — the sync rule below is the deliberate exception, since an agent that opens only one of the two files still needs it.
 
 ## Keep These Two Files in Sync
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A template project for using p5.js with TypeScript and webpack.
 
 ## Quickstart
 
-[Quickstart Guide](https://blwatkins.github.io/p5-webpack-typescript-template/quickstart.html)
+- [Quickstart Guide](https://blwatkins.github.io/p5-webpack-typescript-template/quickstart.html)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ A template project for using p5.js with TypeScript and webpack.
 
 ## Quickstart
 
-[Quickstart Guide](./quickstart.md)
+- [Quickstart Guide](./quickstart.md)
 
 ## License
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,7 @@ Production and development builds are written to the `_dist/` directory, which i
 
 ### Running the Sketch on a localhost Development Server
 
-To test your sketch, navigate to the project directory in your terminal and run the following command:
+To run your sketch, navigate to the project directory in your terminal and run the following command:
 
 ```shell
 npm run dev
@@ -64,8 +64,8 @@ Development server settings live alongside the build configuration in `webpack.c
 - `npm run build` - bundle the sketch source code and dependencies with `webpack` in production mode
 - `npm run build:dev` - bundle the sketch source code and dependencies with `webpack` in development mode
 - `npm run build:check` - run both build scripts in sequence
-- `npm run serve` - bundle the sketch in production mode, start a localhost development server, and open a new browser window for the `index.html` file bundled with the compiled sketch
-- `npm run dev` - bundle the sketch in development mode, start a localhost development server, and open a new browser window for the `index.html` file bundled with the compiled sketch
+- `npm run preview` - bundle the sketch in production mode, start a localhost development server, and open a new browser window
+- `npm run dev` - bundle the sketch in development mode, start a localhost development server, and open a new browser window
 - `npm run test` - placeholder for a future test runner; the template ships none, and the script exits with an error until one is added
 - `npm run validate` - run lint and build checks in sequence
 
@@ -77,6 +77,10 @@ For additional information about the software and tools discussed in this guide,
 
 - [Node.js](https://nodejs.org/en/)
 - [npm](https://docs.npmjs.com/cli)
+
+### webpack
+
+- [webpack](https://webpack.js.org/)
 
 ### Text Editor and IDE Resources
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ layout: post
 author:
   - Brittni Watkins
 date: 2026-07-30
-modified_date: 2026-08-06
+modified_date: 2026-08-08
 toc: true
 ---
 
@@ -78,7 +78,7 @@ For additional information about the software and tools discussed in this guide,
 - [Node.js](https://nodejs.org/en/)
 - [npm](https://docs.npmjs.com/cli)
 
-### webpack
+### webpack Resources
 
 - [webpack](https://webpack.js.org/)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,21 +73,6 @@ Development server settings live alongside the build configuration in `webpack.c
 
 For additional information about the software and tools discussed in this guide, the following resources may be helpful:
 
-### Node.js and npm Resources
-
-- [Node.js](https://nodejs.org/en/)
-- [npm](https://docs.npmjs.com/cli)
-
-### webpack Resources
-
-- [webpack](https://webpack.js.org/)
-
-### Text Editor and IDE Resources
-
-- [Visual Studio Code](https://code.visualstudio.com/)
-- [WebStorm](https://www.jetbrains.com/webstorm/)
-- [Sublime Text](https://www.sublimetext.com/)
-
 ### Git and GitHub Resources
 
 - [GitHub Docs - Creating a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
     "build:check": "npm run build:dev && npm run build",
-    "serve": "webpack-dev-server --mode production",
+    "preview": "webpack-dev-server --mode production",
     "dev": "webpack-dev-server --mode development",
     "test": "echo \"Error: no test specified\" && exit 1",
     "validate": "npm run lint:all && npm run build:check"


### PR DESCRIPTION
Renames the `serve` npm script to `preview` and refreshes the documentation around it.

- `package.json`: `serve` → `preview` (`webpack-dev-server --mode production`); behavior unchanged
- Script list updated in `.github/copilot-instructions.md` and `docs/quickstart.md`
- Trimmed tool-homepage links (Node.js, npm, editors) from the quickstart Resources section; the remaining entries are task-oriented
- Documented the `modified_date` front matter convention in `.github/copilot-instructions.md`
- Quickstart links in `README.md` and `docs/index.md` converted to list items, matching the Sources and Technical Notes section
- Dropped the stale **GitHub Repository Topics** bullet from the template-adaptation checklist; that section no longer exists
- Portfolio review naming rule now states the convention (match each tool's own capitalization) instead of a single example pair
- Rewrote the `CLAUDE.md` sync rule in both files: the trigger is now two mechanical tests — a link stops resolving, or a restated fact stops matching — instead of an enumerated list of content items. This removes the per-repo coupling and fixes a circular trigger that could never fire for a newly added section
- The Instruction File Sync review step now states those two checks directly, and the template-adaptation checklist covers the companion `CLAUDE.md`

**Breaking for downstream template users:** `npm run serve` no longer exists — use `npm run preview`.

*PR description written by Claude Code.*